### PR TITLE
Mapping-like interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.*.sw?
+*.pyc
+*~
+.idea/*
+dist/*
+build/*
+*.egg-info/*
+.idea/*
+.coverage
+reg_settings.py
+MANIFEST
+.directory

--- a/cachecore/core.py
+++ b/cachecore/core.py
@@ -59,6 +59,7 @@ put it into your WSGI application).
 import os
 import re
 import tempfile
+from collections import MutableMapping
 try:
     from hashlib import md5
 except ImportError:
@@ -89,7 +90,7 @@ def _items(mappingorseq):
         else mappingorseq
 
 
-class BaseCache(object):
+class BaseCache(MutableMapping):
     """Baseclass for the cache systems.  All the cache systems implement this
     API or a superset of it.
 
@@ -98,7 +99,14 @@ class BaseCache(object):
     """
 
     def __init__(self, default_timeout=300):
+        super(BaseCache, self).__init__()
         self.default_timeout = default_timeout
+
+    def __iter__(self):
+        raise StopIteration
+
+    def __len__(self):
+        raise NotImplementedError
 
     def get(self, key):
         """Looks up key in the cache and returns the value for it.
@@ -108,6 +116,9 @@ class BaseCache(object):
         """
         return None
 
+    def __getitem__(self, key):
+        return self.get(key)
+
     def delete(self, key):
         """Deletes `key` from the cache.  If it does not exist in the cache
         nothing happens.
@@ -115,6 +126,9 @@ class BaseCache(object):
         :param key: the key to delete.
         """
         pass
+
+    def __delitem__(self, key):
+        return self.delete(key)
 
     def get_many(self, *keys):
         """Returns a list of values for the given keys.
@@ -152,6 +166,9 @@ class BaseCache(object):
                         it uses the default timeout).
         """
         pass
+
+    def __setitem__(self, key, value):
+        return self.set(key, value)
 
     def add(self, key, value, timeout=None):
         """Works like :meth:`set` but does not overwrite the values of already

--- a/test_cachecore.py
+++ b/test_cachecore.py
@@ -6,6 +6,7 @@ import time
 import unittest
 import tempfile
 import shutil
+import collections
 
 from unittest import TestCase
 import cachecore as cache
@@ -76,6 +77,27 @@ class FileSystemCacheTestCase(TestCase):
         cache_files = os.listdir(tmp_dir)
         assert len(cache_files) == 0
         shutil.rmtree(tmp_dir)
+
+
+class MappingTestCase(TestCase):
+    def test_should_have_MutableMapping_methods_and_inherit_from_it(self):
+        self.assertIn(collections.MutableMapping, cache.BaseCache.mro())
+        my_cache = cache.BaseCache()
+        expected_methods = ['setitem', 'getitem', 'delitem', 'iter', 'len']
+        actual_methods = dir(my_cache)
+        for method in expected_methods:
+            self.assertIn('__{}__'.format(method), actual_methods)
+
+    def test_should_be_able_to_use_it_as_a_dict(self):
+        my_cache = cache.SimpleCache()
+        my_cache['python'] = 'rules'
+        my_cache.set('answer', '42')
+        self.assertEquals(my_cache.get('python'), 'rules')
+        self.assertEquals(my_cache['answer'], '42')
+        del my_cache['python']
+        my_cache.delete('answer')
+        self.assertEquals(my_cache['python'], None)
+        self.assertEquals(my_cache['answer'], None)
 
 
 # class RedisCacheTestCase(TestCase):


### PR DESCRIPTION
With these little changes we can use any `BaseCache` child classes as a Python `dict` (using `collections.MutableMapping`), with some little limitations compared to `dict`:
- `iteritems()`, `keys()`, `values()` and `len()` and other methods related to getting all keys/values will not work unless you implement `__iter__` and `__len__` in the child class.
- If my cache doesn't have the key `test` and I execute `my_cache['test']` it **will not** raise `KeyError` like in a `dict`; it'll return `None` (as the current `BaseCache.get` API).

This modification is very handy in cases when we are using `dict`s to store and then need to persist or cache them in some way, since only the line that creates the `dict` needs to be replaced.
